### PR TITLE
feat: add `ALLOWED_TOOLS` support into env

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The server can be configured using the following environment variables:
 | AZURE_DEVOPS_ORG_URL | URL of your Azure DevOps organization | Yes | - |
 | AZURE_DEVOPS_PERSONAL_ACCESS_TOKEN | Your personal access token | Yes | - |
 | AZURE_DEVOPS_PROJECT | Default project to use | Yes | - |
+| ALLOWED_TOOLS | Allowed tools. Separate with comma | No | - (All tools allowed) |
 
 ## Usage
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -20,6 +20,9 @@ startCommand:
       AZURE_DEVOPS_PROJECT:
         type: string
         description: Default Azure DevOps project to use
+      ALLOWED_TOOLS:
+        type: string
+        description: Allowed tools. Separate with comma
   commandFunction:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
@@ -29,7 +32,8 @@ startCommand:
       env: {
         AZURE_DEVOPS_ORG_URL: config.AZURE_DEVOPS_ORG_URL,
         AZURE_DEVOPS_PERSONAL_ACCESS_TOKEN: config.AZURE_DEVOPS_PERSONAL_ACCESS_TOKEN,
-        AZURE_DEVOPS_PROJECT: config.AZURE_DEVOPS_PROJECT
+        AZURE_DEVOPS_PROJECT: config.AZURE_DEVOPS_PROJECT,
+        ALLOWED_TOOLS: config.ALLOWED_TOOLS
       }
     })
   exampleConfig:

--- a/src/Tools/AIAssistedDevelopmentTools.ts
+++ b/src/Tools/AIAssistedDevelopmentTools.ts
@@ -15,6 +15,7 @@ import {
   PredictBuildFailuresParams,
   OptimizeTestSelectionParams
 } from "../Interfaces/AIAssisted";
+import getClassMethods from "../utils/getClassMethods";
 
 export class AIAssistedDevelopmentTools {
   private service: AIAssistedDevelopmentService;
@@ -142,4 +143,6 @@ export class AIAssistedDevelopmentTools {
       return formatErrorResponse(error);
     }
   }
-} 
+}
+
+export const AIAssistedDevelopmentToolMethods = getClassMethods(AIAssistedDevelopmentTools.prototype);

--- a/src/Tools/ArtifactManagementTools.ts
+++ b/src/Tools/ArtifactManagementTools.ts
@@ -15,6 +15,7 @@ import {
   CreatePackageDownloadReportParams,
   CheckPackageDependenciesParams
 } from "../Interfaces/ArtifactManagement";
+import getClassMethods from "../utils/getClassMethods";
 
 export class ArtifactManagementTools {
   private service: ArtifactManagementService;
@@ -148,4 +149,6 @@ export class ArtifactManagementTools {
       return formatErrorResponse(error);
     }
   }
-} 
+}
+
+export const ArtifactManagementToolMethods = getClassMethods(ArtifactManagementTools.prototype);

--- a/src/Tools/BoardsSprintsTools.ts
+++ b/src/Tools/BoardsSprintsTools.ts
@@ -12,6 +12,7 @@ import {
   GetSprintCapacityParams,
   GetTeamMembersParams
 } from '../Interfaces/BoardsAndSprints';
+import getClassMethods from "../utils/getClassMethods";
 
 export class BoardsSprintsTools {
   private boardsSprintsService: BoardsSprintsService;
@@ -136,4 +137,6 @@ export class BoardsSprintsTools {
       return formatErrorResponse(error);
     }
   }
-} 
+}
+
+export const BoardsSprintsToolMethods = getClassMethods(BoardsSprintsTools.prototype);

--- a/src/Tools/DevSecOpsTools.ts
+++ b/src/Tools/DevSecOpsTools.ts
@@ -16,6 +16,7 @@ import {
   AuditSecretUsageParams,
   VaultIntegrationParams
 } from "../Interfaces/DevSecOps";
+import getClassMethods from "../utils/getClassMethods";
 
 export class DevSecOpsTools {
   private service: DevSecOpsService;
@@ -153,4 +154,6 @@ export class DevSecOpsTools {
       return formatErrorResponse(error);
     }
   }
-} 
+}
+
+export const DevSecOpsToolMethods = getClassMethods(DevSecOpsTools.prototype);

--- a/src/Tools/GitTools.ts
+++ b/src/Tools/GitTools.ts
@@ -17,6 +17,7 @@ import {
   ApprovePullRequestParams,
   MergePullRequestParams
 } from '../Interfaces/CodeAndRepositories';
+import getClassMethods from "../utils/getClassMethods";
 
 export class GitTools {
   private gitService: GitService;
@@ -206,4 +207,6 @@ export class GitTools {
       return formatErrorResponse(error);
     }
   }
-} 
+}
+
+export const GitToolMethods = getClassMethods(GitTools.prototype);

--- a/src/Tools/ProjectTools.ts
+++ b/src/Tools/ProjectTools.ts
@@ -13,6 +13,7 @@ import {
   GetWorkItemTypesParams,
   GetWorkItemTypeFieldsParams
 } from '../Interfaces/ProjectManagement';
+import getClassMethods from "../utils/getClassMethods";
 
 export class ProjectTools {
   private projectService: ProjectService;
@@ -150,4 +151,6 @@ export class ProjectTools {
       return formatErrorResponse(error);
     }
   }
-} 
+}
+
+export const ProjectToolMethods = getClassMethods(ProjectTools.prototype);

--- a/src/Tools/TestingCapabilitiesTools.ts
+++ b/src/Tools/TestingCapabilitiesTools.ts
@@ -17,6 +17,7 @@ import {
   ConvertFindingsToWorkItemsParams,
   GetExploratoryTestStatisticsParams
 } from "../Interfaces/TestingCapabilities";
+import getClassMethods from "../utils/getClassMethods";
 
 export class TestingCapabilitiesTools {
   private service: TestingCapabilitiesService;
@@ -164,4 +165,6 @@ export class TestingCapabilitiesTools {
       return formatErrorResponse(error);
     }
   }
-} 
+}
+
+export const TestingCapabilitiesToolMethods = getClassMethods(TestingCapabilitiesTools.prototype);

--- a/src/Tools/WorkItemTools.ts
+++ b/src/Tools/WorkItemTools.ts
@@ -14,6 +14,7 @@ import {
   CreateLinkParams,
   BulkWorkItemParams
 } from '../Interfaces/WorkItems';
+import getClassMethods from "../utils/getClassMethods";
 
 export class WorkItemTools {
   private workItemService: WorkItemService;
@@ -177,4 +178,6 @@ export class WorkItemTools {
       return formatErrorResponse(error);
     }
   }
-} 
+}
+
+export const WorkItemToolMethods = getClassMethods(WorkItemTools.prototype);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,14 @@ import dotenv from 'dotenv';
 import path from 'path';
 import fs from 'fs';
 import { AzureDevOpsConfig } from './Interfaces/AzureDevOps';
+import { AIAssistedDevelopmentToolMethods } from './Tools/AIAssistedDevelopmentTools';
+import { ArtifactManagementToolMethods } from './Tools/ArtifactManagementTools';
+import { BoardsSprintsToolMethods } from './Tools/BoardsSprintsTools';
+import { DevSecOpsToolMethods } from './Tools/DevSecOpsTools';
+import { GitToolMethods } from './Tools/GitTools';
+import { ProjectToolMethods } from './Tools/ProjectTools';
+import { TestingCapabilitiesToolMethods } from './Tools/TestingCapabilitiesTools';
+import { WorkItemToolMethods } from './Tools/WorkItemTools';
 
 // Try to load environment variables from .env file with multiple possible locations
 function loadEnvFile() {
@@ -59,7 +67,23 @@ export function getAzureDevOpsConfig(): AzureDevOpsConfig {
   };
 }
 
+const ALL_ALLOWED_TOOLS = AIAssistedDevelopmentToolMethods
+  .concat(ArtifactManagementToolMethods)
+  .concat(BoardsSprintsToolMethods)
+  .concat(DevSecOpsToolMethods)
+  .concat(GitToolMethods)
+  .concat(ProjectToolMethods)
+  .concat(TestingCapabilitiesToolMethods)
+  .concat(WorkItemToolMethods);
+
+/**
+ * Get allowed tools from `process.env.ALLOWED_TOOLS`.
+ * 
+ * For backward compatibility, if `process.env.ALLOWED_TOOLS` is `undefined`, all tools are allowed.
+ */
 export function getAllowedTools(): Set<string> {
-  const allowedTools = (process.env.ALLOWED_TOOLS || '').split(',');
+  const ALLOWED_TOOLS = process.env.ALLOWED_TOOLS;
+  if (!ALLOWED_TOOLS) return new Set(ALL_ALLOWED_TOOLS);
+  const allowedTools = ALLOWED_TOOLS.split(',');
   return new Set(allowedTools);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,3 +58,8 @@ export function getAzureDevOpsConfig(): AzureDevOpsConfig {
     personalAccessToken
   };
 }
+
+export function getAllowedTools(): Set<string> {
+  const allowedTools = (process.env.ALLOWED_TOOLS || '').split(',');
+  return new Set(allowedTools);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { getAzureDevOpsConfig } from './config';
+import { getAllowedTools, getAzureDevOpsConfig } from './config';
 import { WorkItemTools } from './Tools/WorkItemTools';
 import { BoardsSprintsTools } from './Tools/BoardsSprintsTools';
 import { ProjectTools } from './Tools/ProjectTools';
@@ -19,6 +19,10 @@ async function main() {
     // Load configuration
     const azureDevOpsConfig = getAzureDevOpsConfig();
     console.log('Successfully loaded Azure DevOps configuration');
+
+    // Load allowed tools
+    const allowedTools = getAllowedTools();
+    console.log('Successfully loaded allowed tools');
     
     // Initialize tools
     const workItemTools = new WorkItemTools(azureDevOpsConfig);
@@ -40,7 +44,7 @@ async function main() {
     });
 
     // Register Work Item Tools
-    server.tool("listWorkItems", 
+    allowedTools.has("listWorkItems") && server.tool("listWorkItems", 
       "List work items based on a WIQL query",
       {
         query: z.string().describe("WIQL query to get work items")
@@ -55,7 +59,7 @@ async function main() {
       }
     );
     
-    server.tool("getWorkItemById", 
+    allowedTools.has("getWorkItemById") && server.tool("getWorkItemById", 
       "Get a specific work item by ID",
       {
         id: z.number().describe("Work item ID")
@@ -70,7 +74,7 @@ async function main() {
       }
     );
     
-    server.tool("searchWorkItems", 
+    allowedTools.has("searchWorkItems") && server.tool("searchWorkItems", 
       "Search for work items by text",
       {
         searchText: z.string().describe("Text to search for in work items"),
@@ -86,7 +90,7 @@ async function main() {
       }
     );
     
-    server.tool("getRecentlyUpdatedWorkItems", 
+    allowedTools.has("getRecentlyUpdatedWorkItems") && server.tool("getRecentlyUpdatedWorkItems", 
       "Get recently updated work items",
       {
         top: z.number().optional().describe("Maximum number of work items to return"),
@@ -102,7 +106,7 @@ async function main() {
       }
     );
     
-    server.tool("getMyWorkItems", 
+    allowedTools.has("getMyWorkItems") && server.tool("getMyWorkItems", 
       "Get work items assigned to you",
       {
         state: z.string().optional().describe("Filter by work item state"),
@@ -118,7 +122,7 @@ async function main() {
       }
     );
     
-    server.tool("createWorkItem", 
+    allowedTools.has("createWorkItem") && server.tool("createWorkItem", 
       "Create a new work item",
       {
         workItemType: z.string().describe("Type of work item to create"),
@@ -140,7 +144,7 @@ async function main() {
       }
     );
     
-    server.tool("updateWorkItem", 
+    allowedTools.has("updateWorkItem") && server.tool("updateWorkItem", 
       "Update an existing work item",
       {
         id: z.number().describe("ID of the work item to update"),
@@ -156,7 +160,7 @@ async function main() {
       }
     );
     
-    server.tool("addWorkItemComment", 
+    allowedTools.has("addWorkItemComment") && server.tool("addWorkItemComment", 
       "Add a comment to a work item",
       {
         id: z.number().describe("ID of the work item"),
@@ -172,7 +176,7 @@ async function main() {
       }
     );
     
-    server.tool("updateWorkItemState", 
+    allowedTools.has("updateWorkItemState") && server.tool("updateWorkItemState", 
       "Update the state of a work item",
       {
         id: z.number().describe("ID of the work item"),
@@ -189,7 +193,7 @@ async function main() {
       }
     );
     
-    server.tool("assignWorkItem", 
+    allowedTools.has("assignWorkItem") && server.tool("assignWorkItem", 
       "Assign a work item to a user",
       {
         id: z.number().describe("ID of the work item"),
@@ -205,7 +209,7 @@ async function main() {
       }
     );
     
-    server.tool("createLink", 
+    allowedTools.has("createLink") && server.tool("createLink", 
       "Create a link between work items",
       {
         sourceId: z.number().describe("ID of the source work item"),
@@ -223,7 +227,7 @@ async function main() {
       }
     );
     
-    server.tool("bulkCreateWorkItems", 
+    allowedTools.has("bulkCreateWorkItems") && server.tool("bulkCreateWorkItems", 
       "Create or update multiple work items in a single operation",
       {
         workItems: z.array(z.any()).describe("Array of work items to create or update")
@@ -239,7 +243,7 @@ async function main() {
     );
     
     // Register Boards & Sprints Tools
-    server.tool("getBoards", 
+    allowedTools.has("getBoards") && server.tool("getBoards", 
       "Get all boards for a team",
       {
         teamId: z.string().optional().describe("Team ID (uses default team if not specified)")
@@ -254,7 +258,7 @@ async function main() {
       }
     );
     
-    server.tool("getBoardColumns", 
+    allowedTools.has("getBoardColumns") && server.tool("getBoardColumns", 
       "Get columns for a specific board",
       {
         teamId: z.string().optional().describe("Team ID (uses default team if not specified)"),
@@ -270,7 +274,7 @@ async function main() {
       }
     );
     
-    server.tool("getBoardItems", 
+    allowedTools.has("getBoardItems") && server.tool("getBoardItems", 
       "Get items on a specific board",
       {
         teamId: z.string().optional().describe("Team ID (uses default team if not specified)"),
@@ -286,7 +290,7 @@ async function main() {
       }
     );
     
-    server.tool("moveCardOnBoard", 
+    allowedTools.has("moveCardOnBoard") && server.tool("moveCardOnBoard", 
       "Move a card on a board",
       {
         teamId: z.string().optional().describe("Team ID (uses default team if not specified)"),
@@ -305,7 +309,7 @@ async function main() {
       }
     );
     
-    server.tool("getSprints", 
+    allowedTools.has("getSprints") && server.tool("getSprints", 
       "Get all sprints for a team",
       {
         teamId: z.string().optional().describe("Team ID (uses default team if not specified)")
@@ -320,7 +324,7 @@ async function main() {
       }
     );
     
-    server.tool("getCurrentSprint", 
+    allowedTools.has("getCurrentSprint") && server.tool("getCurrentSprint", 
       "Get the current sprint",
       {
         teamId: z.string().optional().describe("Team ID (uses default team if not specified)")
@@ -335,7 +339,7 @@ async function main() {
       }
     );
     
-    server.tool("getSprintWorkItems", 
+    allowedTools.has("getSprintWorkItems") && server.tool("getSprintWorkItems", 
       "Get work items in a specific sprint",
       {
         teamId: z.string().optional().describe("Team ID (uses default team if not specified)"),
@@ -351,7 +355,7 @@ async function main() {
       }
     );
     
-    server.tool("getSprintCapacity", 
+    allowedTools.has("getSprintCapacity") && server.tool("getSprintCapacity", 
       "Get capacity for a specific sprint",
       {
         teamId: z.string().optional().describe("Team ID (uses default team if not specified)"),
@@ -367,7 +371,7 @@ async function main() {
       }
     );
     
-    server.tool("getTeamMembers", 
+    allowedTools.has("getTeamMembers") && server.tool("getTeamMembers", 
       "Get members of a team",
       {
         teamId: z.string().optional().describe("Team ID (uses default team if not specified)")
@@ -383,7 +387,7 @@ async function main() {
     );
     
     // Register Project Tools
-    server.tool("listProjects", 
+    allowedTools.has("listProjects") && server.tool("listProjects", 
       "List all projects",
       {
         stateFilter: z.enum(['all', 'createPending', 'deleted', 'deleting', 'new', 'unchanged', 'wellFormed']).optional().describe("Filter by project state"),
@@ -400,7 +404,7 @@ async function main() {
       }
     );
     
-    server.tool("getProjectDetails", 
+    allowedTools.has("getProjectDetails") && server.tool("getProjectDetails", 
       "Get details of a specific project",
       {
         projectId: z.string().describe("ID of the project"),
@@ -417,7 +421,7 @@ async function main() {
       }
     );
     
-    server.tool("createProject", 
+    allowedTools.has("createProject") && server.tool("createProject", 
       "Create a new project",
       {
         name: z.string().describe("Name of the project"),
@@ -436,7 +440,7 @@ async function main() {
       }
     );
     
-    server.tool("getAreas", 
+    allowedTools.has("getAreas") && server.tool("getAreas", 
       "Get areas for a project",
       {
         projectId: z.string().describe("ID of the project"),
@@ -452,7 +456,7 @@ async function main() {
       }
     );
     
-    server.tool("getIterations", 
+    allowedTools.has("getIterations") && server.tool("getIterations", 
       "Get iterations for a project",
       {
         projectId: z.string().describe("ID of the project"),
@@ -468,7 +472,7 @@ async function main() {
       }
     );
     
-    server.tool("createArea", 
+    allowedTools.has("createArea") && server.tool("createArea", 
       "Create a new area in a project",
       {
         projectId: z.string().describe("ID of the project"),
@@ -485,7 +489,7 @@ async function main() {
       }
     );
     
-    server.tool("createIteration", 
+    allowedTools.has("createIteration") && server.tool("createIteration", 
       "Create a new iteration in a project",
       {
         projectId: z.string().describe("ID of the project"),
@@ -504,7 +508,7 @@ async function main() {
       }
     );
     
-    server.tool("getProcesses", 
+    allowedTools.has("getProcesses") && server.tool("getProcesses", 
       "Get all processes",
       {
         expandIcon: z.boolean().optional().describe("Include process icons")
@@ -519,7 +523,7 @@ async function main() {
       }
     );
     
-    server.tool("getWorkItemTypes", 
+    allowedTools.has("getWorkItemTypes") && server.tool("getWorkItemTypes", 
       "Get work item types for a process",
       {
         processId: z.string().describe("ID of the process")
@@ -534,7 +538,7 @@ async function main() {
       }
     );
     
-    server.tool("getWorkItemTypeFields", 
+    allowedTools.has("getWorkItemTypeFields") && server.tool("getWorkItemTypeFields", 
       "Get fields for a work item type",
       {
         processId: z.string().describe("ID of the process"),
@@ -551,7 +555,7 @@ async function main() {
     );
     
     // Register Git Tools
-    server.tool("listRepositories", 
+    allowedTools.has("listRepositories") && server.tool("listRepositories", 
       "List all repositories",
       {
         projectId: z.string().optional().describe("Filter by project"),
@@ -568,7 +572,7 @@ async function main() {
       }
     );
     
-    server.tool("getRepository", 
+    allowedTools.has("getRepository") && server.tool("getRepository", 
       "Get details of a specific repository",
       {
         projectId: z.string().describe("ID of the project"),
@@ -584,7 +588,7 @@ async function main() {
       }
     );
     
-    server.tool("createRepository", 
+    allowedTools.has("createRepository") && server.tool("createRepository", 
       "Create a new repository",
       {
         name: z.string().describe("Name of the repository"),
@@ -600,7 +604,7 @@ async function main() {
       }
     );
     
-    server.tool("listBranches", 
+    allowedTools.has("listBranches") && server.tool("listBranches", 
       "List branches in a repository",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -617,7 +621,7 @@ async function main() {
       }
     );
     
-    server.tool("searchCode", 
+    allowedTools.has("searchCode") && server.tool("searchCode", 
       "Search for code in repositories",
       {
         searchText: z.string().describe("Text to search for"),
@@ -636,7 +640,7 @@ async function main() {
       }
     );
     
-    server.tool("browseRepository", 
+    allowedTools.has("browseRepository") && server.tool("browseRepository", 
       "Browse the contents of a repository",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -657,7 +661,7 @@ async function main() {
       }
     );
     
-    server.tool("getFileContent", 
+    allowedTools.has("getFileContent") && server.tool("getFileContent", 
       "Get the content of a file",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -678,7 +682,7 @@ async function main() {
       }
     );
     
-    server.tool("getCommitHistory", 
+    allowedTools.has("getCommitHistory") && server.tool("getCommitHistory", 
       "Get commit history for a repository",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -696,7 +700,7 @@ async function main() {
       }
     );
     
-    server.tool("listPullRequests", 
+    allowedTools.has("listPullRequests") && server.tool("listPullRequests", 
       "List pull requests",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -716,7 +720,7 @@ async function main() {
       }
     );
     
-    server.tool("createPullRequest", 
+    allowedTools.has("createPullRequest") && server.tool("createPullRequest", 
       "Create a new pull request",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -736,7 +740,7 @@ async function main() {
       }
     );
     
-    server.tool("getPullRequest", 
+    allowedTools.has("getPullRequest") && server.tool("getPullRequest", 
       "Get details of a specific pull request",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -752,7 +756,7 @@ async function main() {
       }
     );
     
-    server.tool("getPullRequestComments", 
+    allowedTools.has("getPullRequestComments") && server.tool("getPullRequestComments", 
       "Get comments on a pull request",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -771,7 +775,7 @@ async function main() {
       }
     );
     
-    server.tool("approvePullRequest", 
+    allowedTools.has("approvePullRequest") && server.tool("approvePullRequest", 
       "Approve a pull request",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -787,7 +791,7 @@ async function main() {
       }
     );
     
-    server.tool("mergePullRequest", 
+    allowedTools.has("mergePullRequest") && server.tool("mergePullRequest", 
       "Merge a pull request",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -806,7 +810,7 @@ async function main() {
     );
     
     // Register Testing Capabilities Tools
-    server.tool("runAutomatedTests", 
+    allowedTools.has("runAutomatedTests") && server.tool("runAutomatedTests", 
       "Execute automated test suites",
       {
         testSuiteId: z.number().optional().describe("ID of the test suite to run"),
@@ -824,7 +828,7 @@ async function main() {
       }
     );
     
-    server.tool("getTestAutomationStatus", 
+    allowedTools.has("getTestAutomationStatus") && server.tool("getTestAutomationStatus", 
       "Check status of automated test execution",
       {
         testRunId: z.number().describe("ID of the test run to check status for")
@@ -839,7 +843,7 @@ async function main() {
       }
     );
     
-    server.tool("configureTestAgents", 
+    allowedTools.has("configureTestAgents") && server.tool("configureTestAgents", 
       "Configure and manage test agents",
       {
         agentName: z.string().describe("Name of the test agent to configure"),
@@ -856,7 +860,7 @@ async function main() {
       }
     );
     
-    server.tool("createTestDataGenerator", 
+    allowedTools.has("createTestDataGenerator") && server.tool("createTestDataGenerator", 
       "Generate test data for automated tests",
       {
         name: z.string().describe("Name of the test data generator"),
@@ -873,7 +877,7 @@ async function main() {
       }
     );
     
-    server.tool("manageTestEnvironments", 
+    allowedTools.has("manageTestEnvironments") && server.tool("manageTestEnvironments", 
       "Manage test environments for different test types",
       {
         environmentName: z.string().describe("Name of the test environment"),
@@ -890,7 +894,7 @@ async function main() {
       }
     );
     
-    server.tool("getTestFlakiness", 
+    allowedTools.has("getTestFlakiness") && server.tool("getTestFlakiness", 
       "Analyze and report on test flakiness",
       {
         testId: z.number().optional().describe("ID of a specific test to analyze"),
@@ -907,7 +911,7 @@ async function main() {
       }
     );
     
-    server.tool("getTestGapAnalysis", 
+    allowedTools.has("getTestGapAnalysis") && server.tool("getTestGapAnalysis", 
       "Identify gaps in test coverage",
       {
         areaPath: z.string().optional().describe("Area path to analyze"),
@@ -923,7 +927,7 @@ async function main() {
       }
     );
     
-    server.tool("runTestImpactAnalysis", 
+    allowedTools.has("runTestImpactAnalysis") && server.tool("runTestImpactAnalysis", 
       "Determine which tests to run based on code changes",
       {
         buildId: z.number().describe("ID of the build to analyze"),
@@ -939,7 +943,7 @@ async function main() {
       }
     );
     
-    server.tool("getTestHealthDashboard", 
+    allowedTools.has("getTestHealthDashboard") && server.tool("getTestHealthDashboard", 
       "View overall test health metrics",
       {
         timeRange: z.string().optional().describe("Time range for metrics (e.g., '90d')"),
@@ -955,7 +959,7 @@ async function main() {
       }
     );
     
-    server.tool("runTestOptimization", 
+    allowedTools.has("runTestOptimization") && server.tool("runTestOptimization", 
       "Optimize test suite execution for faster feedback",
       {
         testPlanId: z.number().describe("ID of the test plan to optimize"),
@@ -971,7 +975,7 @@ async function main() {
       }
     );
     
-    server.tool("createExploratorySessions", 
+    allowedTools.has("createExploratorySessions") && server.tool("createExploratorySessions", 
       "Create new exploratory testing sessions",
       {
         title: z.string().describe("Title of the exploratory session"),
@@ -988,7 +992,7 @@ async function main() {
       }
     );
     
-    server.tool("recordExploratoryTestResults", 
+    allowedTools.has("recordExploratoryTestResults") && server.tool("recordExploratoryTestResults", 
       "Record findings during exploratory testing",
       {
         sessionId: z.number().describe("ID of the exploratory session"),
@@ -1005,7 +1009,7 @@ async function main() {
       }
     );
     
-    server.tool("convertFindingsToWorkItems", 
+    allowedTools.has("convertFindingsToWorkItems") && server.tool("convertFindingsToWorkItems", 
       "Convert exploratory test findings to work items",
       {
         sessionId: z.number().describe("ID of the exploratory session"),
@@ -1022,7 +1026,7 @@ async function main() {
       }
     );
     
-    server.tool("getExploratoryTestStatistics", 
+    allowedTools.has("getExploratoryTestStatistics") && server.tool("getExploratoryTestStatistics", 
       "Get statistics on exploratory testing activities",
       {
         timeRange: z.string().optional().describe("Time range for statistics (e.g., '90d')"),
@@ -1039,7 +1043,7 @@ async function main() {
     );
     
     // Register DevSecOps Tools
-    server.tool("runSecurityScan", 
+    allowedTools.has("runSecurityScan") && server.tool("runSecurityScan", 
       "Run security scans on repositories",
       {
         repositoryId: z.string().describe("ID of the repository to scan"),
@@ -1056,7 +1060,7 @@ async function main() {
       }
     );
     
-    server.tool("getSecurityScanResults", 
+    allowedTools.has("getSecurityScanResults") && server.tool("getSecurityScanResults", 
       "Get results from security scans",
       {
         scanId: z.string().describe("ID of the scan to get results for"),
@@ -1072,7 +1076,7 @@ async function main() {
       }
     );
     
-    server.tool("trackSecurityVulnerabilities", 
+    allowedTools.has("trackSecurityVulnerabilities") && server.tool("trackSecurityVulnerabilities", 
       "Track and manage security vulnerabilities",
       {
         vulnerabilityId: z.string().optional().describe("ID of a specific vulnerability to track"),
@@ -1089,7 +1093,7 @@ async function main() {
       }
     );
     
-    server.tool("generateSecurityCompliance", 
+    allowedTools.has("generateSecurityCompliance") && server.tool("generateSecurityCompliance", 
       "Generate security compliance reports",
       {
         standardType: z.enum(['owasp', 'pci-dss', 'hipaa', 'gdpr', 'iso27001', 'custom']).optional().describe("Compliance standard to report on"),
@@ -1105,7 +1109,7 @@ async function main() {
       }
     );
     
-    server.tool("integrateSarifResults", 
+    allowedTools.has("integrateSarifResults") && server.tool("integrateSarifResults", 
       "Import and process SARIF format security results",
       {
         sarifFilePath: z.string().describe("Path to the SARIF file to import"),
@@ -1121,7 +1125,7 @@ async function main() {
       }
     );
     
-    server.tool("runComplianceChecks", 
+    allowedTools.has("runComplianceChecks") && server.tool("runComplianceChecks", 
       "Run compliance checks against standards",
       {
         complianceStandard: z.string().describe("Compliance standard to check against"),
@@ -1137,7 +1141,7 @@ async function main() {
       }
     );
     
-    server.tool("getComplianceStatus", 
+    allowedTools.has("getComplianceStatus") && server.tool("getComplianceStatus", 
       "Get current compliance status",
       {
         standardId: z.string().optional().describe("ID of the compliance standard"),
@@ -1153,7 +1157,7 @@ async function main() {
       }
     );
     
-    server.tool("createComplianceReport", 
+    allowedTools.has("createComplianceReport") && server.tool("createComplianceReport", 
       "Create compliance reports for auditing",
       {
         standardId: z.string().describe("ID of the compliance standard"),
@@ -1169,7 +1173,7 @@ async function main() {
       }
     );
     
-    server.tool("manageSecurityPolicies", 
+    allowedTools.has("manageSecurityPolicies") && server.tool("manageSecurityPolicies", 
       "Manage security policies",
       {
         policyName: z.string().describe("Name of the security policy"),
@@ -1186,7 +1190,7 @@ async function main() {
       }
     );
     
-    server.tool("trackSecurityAwareness", 
+    allowedTools.has("trackSecurityAwareness") && server.tool("trackSecurityAwareness", 
       "Track security awareness and training",
       {
         teamId: z.string().optional().describe("ID of the team to track"),
@@ -1203,7 +1207,7 @@ async function main() {
       }
     );
     
-    server.tool("rotateSecrets", 
+    allowedTools.has("rotateSecrets") && server.tool("rotateSecrets", 
       "Rotate secrets and credentials",
       {
         secretName: z.string().optional().describe("Name of the secret to rotate"),
@@ -1220,7 +1224,7 @@ async function main() {
       }
     );
     
-    server.tool("auditSecretUsage", 
+    allowedTools.has("auditSecretUsage") && server.tool("auditSecretUsage", 
       "Audit usage of secrets across services",
       {
         secretName: z.string().optional().describe("Name of the secret to audit"),
@@ -1236,7 +1240,7 @@ async function main() {
       }
     );
     
-    server.tool("vaultIntegration", 
+    allowedTools.has("vaultIntegration") && server.tool("vaultIntegration", 
       "Integrate with secret vaults",
       {
         vaultUrl: z.string().describe("URL of the vault to integrate with"),
@@ -1255,7 +1259,7 @@ async function main() {
     );
     
     // Register ArtifactManagement Tools
-    server.tool("listArtifactFeeds", 
+    allowedTools.has("listArtifactFeeds") && server.tool("listArtifactFeeds", 
       "List artifact feeds in the organization",
       {
         feedType: z.enum(['npm', 'nuget', 'maven', 'python', 'universal', 'all']).optional().describe("Type of feeds to list"),
@@ -1271,7 +1275,7 @@ async function main() {
       }
     );
     
-    server.tool("getPackageVersions", 
+    allowedTools.has("getPackageVersions") && server.tool("getPackageVersions", 
       "Get versions of a package in a feed",
       {
         feedId: z.string().describe("ID of the feed"),
@@ -1288,7 +1292,7 @@ async function main() {
       }
     );
     
-    server.tool("publishPackage", 
+    allowedTools.has("publishPackage") && server.tool("publishPackage", 
       "Publish a package to a feed",
       {
         feedId: z.string().describe("ID of the feed to publish to"),
@@ -1306,7 +1310,7 @@ async function main() {
       }
     );
     
-    server.tool("promotePackage", 
+    allowedTools.has("promotePackage") && server.tool("promotePackage", 
       "Promote a package version between views",
       {
         feedId: z.string().describe("ID of the feed"),
@@ -1325,7 +1329,7 @@ async function main() {
       }
     );
     
-    server.tool("deletePackageVersion", 
+    allowedTools.has("deletePackageVersion") && server.tool("deletePackageVersion", 
       "Delete a version of a package",
       {
         feedId: z.string().describe("ID of the feed"),
@@ -1343,7 +1347,7 @@ async function main() {
       }
     );
     
-    server.tool("listContainerImages", 
+    allowedTools.has("listContainerImages") && server.tool("listContainerImages", 
       "List container images in a repository",
       {
         repositoryName: z.string().optional().describe("Name of the container repository"),
@@ -1360,7 +1364,7 @@ async function main() {
       }
     );
     
-    server.tool("getContainerImageTags", 
+    allowedTools.has("getContainerImageTags") && server.tool("getContainerImageTags", 
       "Get tags for a container image",
       {
         repositoryName: z.string().describe("Name of the container repository"),
@@ -1377,7 +1381,7 @@ async function main() {
       }
     );
     
-    server.tool("scanContainerImage", 
+    allowedTools.has("scanContainerImage") && server.tool("scanContainerImage", 
       "Scan a container image for vulnerabilities and compliance issues",
       {
         repositoryName: z.string().describe("Name of the container repository"),
@@ -1394,7 +1398,7 @@ async function main() {
       }
     );
     
-    server.tool("manageContainerPolicies", 
+    allowedTools.has("manageContainerPolicies") && server.tool("manageContainerPolicies", 
       "Manage policies for container repositories",
       {
         repositoryName: z.string().describe("Name of the container repository"),
@@ -1412,7 +1416,7 @@ async function main() {
       }
     );
     
-    server.tool("manageUniversalPackages", 
+    allowedTools.has("manageUniversalPackages") && server.tool("manageUniversalPackages", 
       "Manage universal packages",
       {
         packageName: z.string().describe("Name of the universal package"),
@@ -1430,7 +1434,7 @@ async function main() {
       }
     );
     
-    server.tool("createPackageDownloadReport", 
+    allowedTools.has("createPackageDownloadReport") && server.tool("createPackageDownloadReport", 
       "Create reports on package downloads",
       {
         feedId: z.string().optional().describe("ID of the feed"),
@@ -1448,7 +1452,7 @@ async function main() {
       }
     );
     
-    server.tool("checkPackageDependencies", 
+    allowedTools.has("checkPackageDependencies") && server.tool("checkPackageDependencies", 
       "Check package dependencies and vulnerabilities",
       {
         packageName: z.string().describe("Name of the package to check"),
@@ -1467,7 +1471,7 @@ async function main() {
     );
     
     // AI Assisted Development Tools
-    server.tool("getAICodeReview", 
+    allowedTools.has("getAICodeReview") && server.tool("getAICodeReview", 
       "Get AI-based code review suggestions",
       {
         pullRequestId: z.number().optional().describe("ID of the pull request to review"),
@@ -1484,7 +1488,7 @@ async function main() {
       }
     );
 
-    server.tool("suggestCodeOptimization", 
+    allowedTools.has("suggestCodeOptimization") && server.tool("suggestCodeOptimization", 
       "Suggest code optimizations using AI",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -1502,7 +1506,7 @@ async function main() {
       }
     );
 
-    server.tool("identifyCodeSmells", 
+    allowedTools.has("identifyCodeSmells") && server.tool("identifyCodeSmells", 
       "Identify potential code smells and anti-patterns",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -1519,7 +1523,7 @@ async function main() {
       }
     );
 
-    server.tool("getPredictiveBugAnalysis", 
+    allowedTools.has("getPredictiveBugAnalysis") && server.tool("getPredictiveBugAnalysis", 
       "Predict potential bugs in code changes",
       {
         repositoryId: z.string().describe("ID of the repository"),
@@ -1536,7 +1540,7 @@ async function main() {
       }
     );
 
-    server.tool("getDeveloperProductivity", 
+    allowedTools.has("getDeveloperProductivity") && server.tool("getDeveloperProductivity", 
       "Measure developer productivity metrics",
       {
         userId: z.string().optional().describe("ID of the user"),
@@ -1553,7 +1557,7 @@ async function main() {
       }
     );
 
-    server.tool("getPredictiveEffortEstimation", 
+    allowedTools.has("getPredictiveEffortEstimation") && server.tool("getPredictiveEffortEstimation", 
       "AI-based effort estimation for work items",
       {
         workItemIds: z.array(z.number()).optional().describe("IDs of work items to estimate"),
@@ -1569,7 +1573,7 @@ async function main() {
       }
     );
 
-    server.tool("getCodeQualityTrends", 
+    allowedTools.has("getCodeQualityTrends") && server.tool("getCodeQualityTrends", 
       "Track code quality trends over time",
       {
         repositoryId: z.string().optional().describe("ID of the repository"),
@@ -1586,7 +1590,7 @@ async function main() {
       }
     );
 
-    server.tool("suggestWorkItemRefinements", 
+    allowedTools.has("suggestWorkItemRefinements") && server.tool("suggestWorkItemRefinements", 
       "Get AI suggestions for work item refinements",
       {
         workItemId: z.number().optional().describe("ID of the work item to refine"),
@@ -1602,7 +1606,7 @@ async function main() {
       }
     );
 
-    server.tool("suggestAutomationOpportunities", 
+    allowedTools.has("suggestAutomationOpportunities") && server.tool("suggestAutomationOpportunities", 
       "Identify opportunities for automation",
       {
         projectId: z.string().optional().describe("ID of the project"),
@@ -1617,7 +1621,7 @@ async function main() {
       }
     );
 
-    server.tool("createIntelligentAlerts", 
+    allowedTools.has("createIntelligentAlerts") && server.tool("createIntelligentAlerts", 
       "Set up intelligent alerts based on patterns",
       {
         alertName: z.string().describe("Name of the alert"),
@@ -1634,7 +1638,7 @@ async function main() {
       }
     );
 
-    server.tool("predictBuildFailures", 
+    allowedTools.has("predictBuildFailures") && server.tool("predictBuildFailures", 
       "Predict potential build failures before they occur",
       {
         buildDefinitionId: z.number().describe("ID of the build definition"),
@@ -1649,7 +1653,7 @@ async function main() {
       }
     );
 
-    server.tool("optimizeTestSelection", 
+    allowedTools.has("optimizeTestSelection") && server.tool("optimizeTestSelection", 
       "Intelligently select tests to run based on changes",
       {
         buildId: z.number().describe("ID of the build"),

--- a/src/utils/getClassMethods.ts
+++ b/src/utils/getClassMethods.ts
@@ -1,0 +1,6 @@
+function getClassMethods (classPrototype: object): string[] {
+  const propertyNames = Object.getOwnPropertyNames(classPrototype);
+  return propertyNames.filter(propertyName => propertyName !== 'constructor');
+}
+
+export default getClassMethods;


### PR DESCRIPTION
Hi, @RyanCardin15 
Thank you for creating this amazing project !!!

Our company is currently using your MCP server with Cursor
But we encountered a problem:
`Currently, Cursor will only send the first 40 tools to the Agent.`
https://docs.cursor.com/context/model-context-protocol#limitations

So I opened this PR
Users can configure `ALLOWED_TOOLS` with env
For backward compatibility, if `process.env.ALLOWED_TOOLS` is `undefined`, all tools are allowed.

I test locally with Cursor.

1.  Specify `ALLOWED_TOOLS`
```json
{
    "mcpServers": {
        "yusheng-test-local-mcp": {
            "command": "node",
            "args": [
               "/Users/yushengchen/work/Thirdparty/AzureDevOps-MCP/dist/index.js"
            ],
            "env": {
                "AZURE_DEVOPS_ORG_URL": "dummy_url",
                "AZURE_DEVOPS_PERSONAL_ACCESS_TOKEN": "dummy_token",
                "AZURE_DEVOPS_PROJECT": "dummy_project",
                "ALLOWED_TOOLS": "getWorkItemById,createPackageDownloadReport"
            }
        }
    }
}
```
<img width="1280" alt="截圖 2025-03-28 下午5 34 04" src="https://github.com/user-attachments/assets/95c6169e-8031-425e-998c-dcb267ca023c" />

2. Ignore `ALLOWED_TOOLS`
```json
{
    "mcpServers": {
        "yusheng-test-local-mcp": {
            "command": "node",
            "args": [
               "/Users/yushengchen/work/Thirdparty/AzureDevOps-MCP/dist/index.js"
            ],
            "env": {
                "AZURE_DEVOPS_ORG_URL": "dummy_url",
                "AZURE_DEVOPS_PERSONAL_ACCESS_TOKEN": "dummy_token",
                "AZURE_DEVOPS_PROJECT": "dummy_project"
            }
        }
    }
}
```
<img width="1280" alt="截圖 2025-03-28 下午5 34 17" src="https://github.com/user-attachments/assets/a7785008-838d-47d8-a46c-035e1cd4744d" />
