### PR TITLE
fix getFileContent

### DIFF
--- a/src/Services/GitService.ts
+++ b/src/Services/GitService.ts
@@ -230,7 +230,9 @@ export class GitService extends AzureDevOpsService {
             const buffer = Buffer.concat(chunks);
             const fileContent = buffer.toString('utf8');
             resolve({
-              content: fileContent
+              content: fileContent,
+              lines: fileContent.split(/\r?\n/),
+              lineCount: fileContent.split(/\r?\n/).length
             });
           });
           
@@ -245,7 +247,9 @@ export class GitService extends AzureDevOpsService {
       }
       
       return {
-        content: fileContent
+        content: fileContent,
+        lines: fileContent.split(/\r?\n/),
+        lineCount: fileContent.split(/\r?\n/).length
       };
     } catch (error) {
       console.error(`Error getting file content for ${params.path}:`, error);


### PR DESCRIPTION
`getFileContent` was previously always returning `[Content not available in this format]`

this PR updates that tool to handle streams which is what [getItemContent](url) provides us.

There is no testing strategy in this repo, so I am unsure how/if that should be set up in this PR.