### PR TITLE
Fix tool validation errors for array parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,18 +233,22 @@ async function main() {
     allowedTools.has("bulkCreateWorkItems") && server.tool("bulkCreateWorkItems", 
       "Create or update multiple work items in a single operation",
       {
-        workItems: z.array(z.object({
-          id: z.number().optional().describe("ID of work item (for updates)"),
-          workItemType: z.string().optional().describe("Type of work item to create"),
-          title: z.string().optional().describe("Title of the work item"),
-          description: z.string().optional().describe("Description of the work item"),
-          assignedTo: z.string().optional().describe("User to assign the work item to"),
-          state: z.string().optional().describe("Initial state of the work item"),
-          areaPath: z.string().optional().describe("Area path for the work item"),
-          iterationPath: z.string().optional().describe("Iteration path for the work item"),
-          additionalFields: z.record(z.any()).optional().describe("Additional fields to set on the work item"),
-          fields: z.record(z.any()).optional().describe("Fields to update on the work item (for updates)")
-        })).min(1).describe("Array of work items to create or update")
+        workItems: z.array(z.union([
+          z.object({
+            workItemType: z.string().describe("Type of work item to create"),
+            title: z.string().describe("Title of the work item"),
+            description: z.string().optional().describe("Description of the work item"),
+            assignedTo: z.string().optional().describe("User to assign the work item to"),
+            state: z.string().optional().describe("Initial state of the work item"),
+            areaPath: z.string().optional().describe("Area path for the work item"),
+            iterationPath: z.string().optional().describe("Iteration path for the work item"),
+            additionalFields: z.record(z.any()).optional().describe("Additional fields to set on the work item")
+          }),
+          z.object({
+            id: z.number().describe("ID of work item to update"),
+            fields: z.record(z.any()).describe("Fields to update on the work item")
+          })
+        ])).min(1).describe("Array of work items to create or update")
       },
       async (params, extra) => {
         const result = await workItemTools.bulkCreateWorkItems(params);

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,18 @@ async function main() {
     allowedTools.has("bulkCreateWorkItems") && server.tool("bulkCreateWorkItems", 
       "Create or update multiple work items in a single operation",
       {
-        workItems: z.array(z.any()).describe("Array of work items to create or update")
+        workItems: z.array(z.object({
+          id: z.number().optional().describe("ID of work item (for updates)"),
+          workItemType: z.string().optional().describe("Type of work item to create"),
+          title: z.string().optional().describe("Title of the work item"),
+          description: z.string().optional().describe("Description of the work item"),
+          assignedTo: z.string().optional().describe("User to assign the work item to"),
+          state: z.string().optional().describe("Initial state of the work item"),
+          areaPath: z.string().optional().describe("Area path for the work item"),
+          iterationPath: z.string().optional().describe("Iteration path for the work item"),
+          additionalFields: z.record(z.any()).optional().describe("Additional fields to set on the work item"),
+          fields: z.record(z.any()).optional().describe("Fields to update on the work item (for updates)")
+        })).min(1).describe("Array of work items to create or update")
       },
       async (params, extra) => {
         const result = await workItemTools.bulkCreateWorkItems(params);
@@ -1000,7 +1011,11 @@ async function main() {
       {
         sessionId: z.number().describe("ID of the exploratory session"),
         findings: z.array(z.string()).describe("List of findings to record"),
-        attachments: z.array(z.any()).optional().describe("Attachments for the findings")
+        attachments: z.array(z.object({
+          name: z.string().describe("Name of the attachment"),
+          content: z.string().describe("Base64 encoded content of the attachment"),
+          contentType: z.string().optional().describe("MIME type of the attachment")
+        })).optional().describe("Attachments for the findings")
       },
       async (params, extra) => {
         const result = await testingCapabilitiesTools.recordExploratoryTestResults(params);


### PR DESCRIPTION
## Summary

This PR fixes the tool validation errors reported in issue #16 where MCP server validation was failing with the error: "tool parameters array type must have items".

## Changes Made

### 1. Fixed `bulkCreateWorkItems` tool schema
- Replaced `z.array(z.any())` with proper union type schema
- Now correctly defines two object types: one for creating work items and one for updating work items
- Ensures required fields (`workItemType`, `title` for create; `id`, `fields` for update) are properly enforced
- Uses `z.union()` to handle both create and update operations

### 2. Fixed `recordExploratoryTestResults` tool schema  
- Replaced `z.array(z.any())` for attachments with proper object schema
- Defined attachment structure with `name`, `content`, and optional `contentType` fields

## Technical Details

The issue was caused by using `z.array(z.any())` which doesn't provide enough type information for MCP validation. The MCP protocol requires array parameters to have properly defined item schemas.

**Before:**
```typescript
workItems: z.array(z.any()).describe("Array of work items to create or update")
```

**After:**
```typescript
workItems: z.array(z.union([
  z.object({
    workItemType: z.string().describe("Type of work item to create"),
    title: z.string().describe("Title of the work item"),
    // ... other create fields
  }),
  z.object({
    id: z.number().describe("ID of work item to update"),
    fields: z.record(z.any()).describe("Fields to update on the work item")
  })
])).min(1).describe("Array of work items to create or update")
```

## Testing

- ✅ TypeScript compilation passes (`npm run build`)
- ✅ Proper type checking for union types
- ✅ Schema validation should now work correctly with MCP clients

## Fixes

Fixes #16

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update