### PR TITLE
Bump @modelcontextprotocol/sdk minimum to ^1.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.6.1",
+    "@modelcontextprotocol/sdk": "^1.23.0",
     "azure-devops-node-api": "^14.1.0",
     "dotenv": "^16.4.7",
     "@azure/identity": "^4.0.0"


### PR DESCRIPTION
Upgrade modelcontextprotocol/sdk so to support Zod4.

This makes progress towards fixing #25 by introducing the Zod4 support that was broken as documented in https://github.com/modelcontextprotocol/typescript-sdk/issues/1143 

In order to ensure a proper fix of #25 however, the package will need to be published by @RyanCardin15 with 

```
npm run build
npm publish
```

After having produced a patch version of the package.