### PR TITLE
fix(deps): bump fast-uri to 3.1.2 to address CVE-2026-6322

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -857,9 +857,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Resolves GHSA-v39h-62p7-jpjc (host confusion via percent-encoded
authority delimiters) and GHSA-q3j6-qgpj-74h6 (path traversal via
percent-encoded dot segments) in the transitive fast-uri dependency.

https://claude.ai/code/session_011GhPjoqY61Qwi8RBzm5RX2